### PR TITLE
add functional for read webpack resolve modules

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,10 @@
 /* @flow */
 
 import Path from 'path'
+import fs from 'fs'
 import resolve from 'resolve'
+
+const filesExt = ['.js', '.jsx'];
 
 function getRootFromConfig () {
   const valInConfug = atom.config.get('declarations-js.rootPath');
@@ -28,10 +31,10 @@ export function processDeclaration(entries: Array<Object>, sourceFile: string): 
   const openProjects = atom.project.getPaths()
   let projectPath
   for (let i = 0, length = openProjects.length; i < length; ++i) {
-  	if (sourceFile.indexOf(openProjects[i]) === 0) {
-  	  projectPath = openProjects[i]
-  	  break
-  	}
+    if (sourceFile.indexOf(openProjects[i]) === 0) {
+      projectPath = openProjects[i]
+      break
+    }
   }
   
   for (let i = 0, length = entries.length; i < length; ++i) {
@@ -55,9 +58,20 @@ export function processDeclaration(entries: Array<Object>, sourceFile: string): 
         for (let j = 0, rootLength = rootsPath.length; j < rootLength; ++j) {
           hasError = false
           try {
-            filePath = resolve.sync('./', {
-              basedir: Path.join(projectPath, rootsPath[j], filePath),
+            let bPath = Path.join(projectPath, rootsPath[j], filePath);
+            let fileName = '';
+            filesExt.forEach(function (ext) {
+              if (fs.existsSync(`${bPath}${ext}`)) {
+                bPath += ext
+                fileName = bPath.replace(/^.*[\\\/]/, '')
+                bPath = Path.dirname(bPath)
+              }
+            });
+        
+            filePath = resolve.sync(`./${fileName}`, {
+              basedir: bPath,
             })
+    
             break
           } catch (_) {
             hasError = true 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,6 +3,17 @@
 import Path from 'path'
 import resolve from 'resolve'
 
+function getRootFromConfig () {
+  const valInConfug = atom.config.get('declarations-js.rootPath');
+  return valInConfug ? valInConfug.split(';') : [];
+}
+
+let rootsPath = getRootFromConfig();
+
+atom.config.onDidChange('declarations-js.rootPath', () => {
+  rootsPath = getRootFromConfig();
+})
+
 export function locToPoint(loc: Object): [number, number] {
   return [loc.line - 1, loc.column]
 }
@@ -13,21 +24,52 @@ export function locToRange(loc: Object): [[number, number], [number, number]] {
 
 export function processDeclaration(entries: Array<Object>, sourceFile: string): Array<Object> {
   const toReturn = []
+  
+  const openProjects = atom.project.getPaths()
+  let projectPath
+  for (let i = 0, length = openProjects.length; i < length; ++i) {
+  	if (sourceFile.indexOf(openProjects[i]) === 0) {
+  	  projectPath = openProjects[i]
+  	  break
+  	}
+  }
+  
   for (let i = 0, length = entries.length; i < length; ++i) {
     const entry = entries[i]
     let filePath = entry.source.filePath
+
     if (filePath) {
       if (resolve.isCore(filePath)) {
         continue
       }
+    
+      let hasError = false
+    
       try {
         filePath = resolve.sync(filePath, {
           basedir: Path.dirname(sourceFile),
         })
       } catch (_) {
+        hasError = true
+        
+        for (let j = 0, rootLength = rootsPath.length; j < rootLength; ++j) {
+          hasError = false
+          try {
+            filePath = resolve.sync('./', {
+              basedir: Path.join(projectPath, rootsPath[j], filePath),
+            })
+            break
+          } catch (_) {
+            hasError = true 
+          }
+        }
+      }
+  
+      if (hasError) {
         continue
       }
     }
+
     toReturn.push({
       range: locToRange(entry.position),
       source: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,16 @@ import { processDeclaration } from './helpers'
 const FLOW_PACKAGES = ['declarations-flow']
 
 export default {
+  config: {
+    rootPath: {
+      type: 'string',
+      title: 'Root folder path',
+      description: 'Specify Root folder path. More than one path separated by ;',
+      default: '',
+      order: 1
+    }
+  },
+	
   activate() {
     if (!atom.inSpecMode()) {
        // eslint-disable-next-line global-require


### PR DESCRIPTION
Hi Steelbrain,
You created a great plugin for Atom, but there is some difficulty with webpack config. It is has this options 
https://webpack.js.org/configuration/resolve/#resolve-modules
(for webpack v1 https://webpack.github.io/docs/configuration.html#resolve-root)

This setting is very powerful, because It allows you to import files from anywhere on a short path. For example:
import button from 'components/Button';

For WebStorm, this is decided by set mark Root for the directory:
https://d3nmt5vlzunoa1.cloudfront.net/webstorm/files/2014/03/image08.png

I added a small option in the settings that allows you to specify the path to the root directory.

Please make a review of the code and add it to the next version of the plugin. Thank you!

my e-mail:a.valuyev@mail.com